### PR TITLE
Add survey on GNNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Contributed by Jie Zhou, Ganqu Cui, Zhengyan Zhang and Yushi Bai.
 
     *Yaochen Xie, Zhao Xu, Jingtun Zhang, Zhangyang Wang, Shuiwang Ji.*
     
+1. **A Network Science perspective of Graph Convolutional Networks: A survey.** arxiv 2023. [paper](https://arxiv.org/abs/2301.04824)
+
+    *Jia, Mingshan and Gabrys, Bogdan and Musial, Katarzyna.*
+
 ## [Models](#content)   
 
 ### [Basic Models](#content)


### PR DESCRIPTION
I've recently shared our new survey on arxiv: [A Network Science perspective of Graph Convolutional Networks: A survey](https://arxiv.org/abs/2301.04824)
We survey GNNs from a graph structural information perspective. We propose novel taxonomies that categorise GNNs from three structural information angles, i.e., the layer-wise message aggregation scope, the message content, and the overall learning scope. Thus adding this paper to the list will make the list more comprehensive and spread awareness of the advances of GNNs.

Thank you for your consideration.